### PR TITLE
[APB-1462][FD] Fix compatibility with the current version of logback-json-logger

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -27,8 +27,8 @@ private object AppDependencies {
   private val pegdownVersion = "1.6.0"
   val compile = Seq(
     "uk.gov.hmrc" %% "http-core" % "0.6.0",
-    "ch.qos.logback" % "logback-core" % "1.2.3",
-    "ch.qos.logback" % "logback-classic" % "1.2.3"
+    "ch.qos.logback" % "logback-core" % "1.1.7",
+    "ch.qos.logback" % "logback-classic" % "1.1.7"
   )
 
   trait TestDependencies {


### PR DESCRIPTION
Without this fix one of our services that uses reactive-circuit-breaker throws an AbstractMethodError on startup. This can be reproduced as follows:
```
cd customer-profile
git checkout master
git pull -r
rm target/universal/stage/RUNNING_PID ; sbt "testProd -Dlogger.resource=application-json-logger.xml"
```